### PR TITLE
fix: disable sentry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ idea.project.settings.runConfigurations {
     'HytaleServer'(org.jetbrains.gradle.ext.Application) {
         mainClass = 'com.hypixel.hytale.Main'
         moduleName = project.idea.module.name + '.main'
-        programParameters = "--allow-op --assets=$hytaleHome/install/$patchline/package/game/latest/Assets.zip"
+        programParameters = "--allow-op --disable-sentry --assets=$hytaleHome/install/$patchline/package/game/latest/Assets.zip"
         if (includes_pack.toBoolean()) {
             programParameters += " --mods=${sourceSets.main.java.srcDirs.first().parentFile.absolutePath}"
         }


### PR DESCRIPTION
Disable sentry to avoid sending crashes during plugin development.

https://support.hytale.com/hc/en-us/articles/45326769420827-Hytale-Server-Manual#disable-sentry-crash-reporting