### PR TITLE
Modify build.gradle and gradle.properties to support any install location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,31 @@ plugins {
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.3'
 }
 
-ext {
-    hytaleHome = "${System.getProperty("user.home")}/AppData/Roaming/Hytale"
+static String expandEnvPaths(String path) {
+    Pattern expr = Pattern.compile("%[A-Za-z0-9-_]+%");
+    Matcher matcher = expr.matcher(path);
+    while (matcher.find()) {
+        String matched = matcher.group();
+        matched = matched.substring(1, matched.length() - 1);
+        String uMatched = matched.toUpperCase();
+        String envValue = System.getenv(uMatched);
+
+        if (envValue == null) {
+            envValue = "%${matched}%";
+
+        } else {
+            envValue = envValue.replace("\\", "\\\\");
+        }
+        Pattern subexpr = Pattern.compile(Pattern.quote(matcher.group(0)));
+        path = subexpr.matcher(path).replaceAll(envValue);
+    }
+    return path;
 }
+ext {
+    // Modify in gradle.properties to point to your Hytale install.
+    hytaleHome = expandEnvPaths(project.hytale_root_directory)
+}
+
 
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(java_version)

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 plugins {
     id 'java'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,7 @@ patchline=release
 # normal player would, instead of adding them as dependencies or adding them
 # to the development server manually.
 load_user_mods=false
+
+# Default location where Hytale is installed.
+# Contains the "install" directory which contains the jar needed for this project.
+hytale_root_directory = %AppData%/Hytale


### PR DESCRIPTION
This pull allows the developer to use any install location (for example, I have Hytale installed under D:\Hytale)
Modifying `hytale_root_directory` to include system environment variables (ie, %D_DRIVE% or %AppData% as used by default) will automatically expand the variable. If the variable isn't found, or is invalid, the base text will be used. 