### PR TITLE
Adding support for mac os

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-import org.codehaus.groovy.runtime.GStringImpl
 
 plugins {
     id 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -67,12 +67,12 @@ idea.project.settings.runConfigurations {
     'HytaleServer'(org.jetbrains.gradle.ext.Application) {
         mainClass = 'com.hypixel.hytale.Main'
         moduleName = project.idea.module.name + '.main'
-        programParameters = "--allow-op --assets=$hytaleHome/install/$patchline/package/game/latest/Assets.zip"
+        programParameters = "--allow-op --assets=${file("$hytaleHome/install/$patchline/package/game/latest/Assets.zip").absolutePath}"
         if (includes_pack.toBoolean()) {
             programParameters += " --mods=${sourceSets.main.java.srcDirs.first().parentFile.absolutePath}"
         }
         if (load_user_mods.toBoolean()) {
-            programParameters += " --mods=$hytaleHome/UserData/Mods"
+            programParameters += " --mods=${file("$hytaleHome/UserData/Mods")}"
         }
         if (use_insecure_auth.toBoolean()) {
             programParameters += " --auth-mode=insecure"

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,19 @@
+import org.codehaus.groovy.runtime.GStringImpl
+
 plugins {
     id 'java'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.3'
 }
 
 ext {
-    hytaleHome = "${System.getProperty("user.home")}/AppData/Roaming/Hytale"
+    def userHomeDirectory = System.getProperty("user.home")
+    def osName = System.getProperty("os.name")
+    if(osName.toLowerCase() == "mac os x"){
+        hytaleHome = "${userHomeDirectory}/Library/Application Support/Hytale"
+    }
+    else if(osName.toLowerCase() == "windows"){
+        hytaleHome = "${userHomeDirectory}/AppData/Roaming/Hytale"
+    }
 }
 
 java {
@@ -64,6 +73,9 @@ idea.project.settings.runConfigurations {
         }
         if (load_user_mods.toBoolean()) {
             programParameters += " --mods=$hytaleHome/UserData/Mods"
+        }
+        if (use_insecure_auth.toBoolean()) {
+            programParameters += " --auth-mode=insecure"
         }
         workingDirectory = serverRunDir.absolutePath
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,5 @@ patchline=release
 # normal player would, instead of adding them as dependencies or adding them
 # to the development server manually.
 load_user_mods=false
+
+use_insecure_auth=false


### PR DESCRIPTION
I changed the path search structure so that the builder itself determines the standard path to hytaleServer based on the operating system. I also added support for spaces in the path.

before:
<img width="965" height="438" alt="before" src="https://github.com/user-attachments/assets/f6c5b853-532c-4299-b89c-2d74b24d2845" />

after:
<img width="965" height="360" alt="after" src="https://github.com/user-attachments/assets/988def6c-b00c-43f0-bfe4-761377e7057f" />
